### PR TITLE
Enviado e-mail ao mudar status do projeto

### DIFF
--- a/app/Http/Controllers/TrabalhoController.php
+++ b/app/Http/Controllers/TrabalhoController.php
@@ -59,6 +59,8 @@ use App\ObjetivoDeDesenvolvimentoSustentavel;
 use App\AvaliacaoRelatorio;
 use App\Curso;
 use Illuminate\Support\Facades\Date;
+use App\Mail\EmailLembrete;
+use App\Mail\MudancaDeStatusDoProjeto;
 
 class TrabalhoController extends Controller
 {
@@ -2223,7 +2225,21 @@ class TrabalhoController extends Controller
         $trabalho->comentario = $request->comentario;
         $trabalho->save();
 
+        $this->enviarEmail($trabalho);
+
         return redirect()->back()->with(['sucesso' => 'Proposta avaliada com sucesso']);
 
     }
+
+    private function enviarEmail(Trabalho $trabalho)
+    {
+        $usuario = DB::table('proponentes')
+        ->join('users', 'proponentes.user_id', '=', 'users.id')
+        ->select('users.*')
+        ->where('proponentes.id', $trabalho->proponente_id)
+        ->first();
+
+        Mail::to($usuario->email)->send(new MudancaDeStatusDoProjeto($usuario, $trabalho));
+    }
+
 }

--- a/app/Mail/MudancaDeStatusDoProjeto.php
+++ b/app/Mail/MudancaDeStatusDoProjeto.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class MudancaDeStatusDoProjeto extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $trabalho;
+    public $usuario;
+    public $assunto;
+    
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct($usuario, $trabalho)
+    {
+        $this->usuario = $usuario;
+        $this->assunto = "O projeto " . strval($trabalho->titulo) . " foi " . strval($trabalho->status);
+        $this->trabalho = $trabalho;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        
+        return $this->from('lmtsteste@gmail.com', 'Submeta - LMTS')
+                    ->subject($this->assunto)
+                    ->view('emails.mudancaDeStatusDoProjeto')
+                    ->with([
+                        'user' => $this->usuario,
+                        'comentario' => $this->trabalho->comentario,
+                    ]);
+    }
+}

--- a/resources/views/emails/mudancaDeStatusDoProjeto.blade.php
+++ b/resources/views/emails/mudancaDeStatusDoProjeto.blade.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <h4>Prezado proponente, </h4>
+    <p>Sua proposta de projeto teve uma atualização no status.</p>
+    <p>Comentário: {{ $comentario }}</p>
+        <p>
+			Atenciosamente,<br>
+			Equipe Submeta.
+        </p>	
+</body>
+</html>


### PR DESCRIPTION
Quando o projeto recebe uma recomendação de proposta, seja aprovada ou não, um e-mail é disparado para notificar o proponente. O campo comentário vai no corpo do e-mail para descrever mais detalhes.